### PR TITLE
feat: add endpoint to sub menu infos

### DIFF
--- a/app/Http/Controllers/GeneralInfoController.php
+++ b/app/Http/Controllers/GeneralInfoController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\GeneralInfoResponse;
+use App\Services\Contracts\GeneralInfoContract;
+
+use Illuminate\Http\Request;
+
+class GeneralInfoController extends Controller
+{
+    private GeneralInfoContract $generalInfoService;
+
+    public function __construct(GeneralInfoContract $generalInfoService)
+    {
+        $this->generalInfoService = $generalInfoService;
+    }
+
+    public function getGeneralInfo()
+    {
+        try {
+            $response = $this->generalInfoService->getGeneralInfo();
+            return response()->json($response);
+        } catch (\Throwable $th) {
+            throw $th;
+        }
+    }
+}

--- a/app/Http/Responses/GeneralInfoResponse.php
+++ b/app/Http/Responses/GeneralInfoResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Responses;
+
+class GeneralInfoResponse {
+    public int $threatened;
+    public int $occurrences;
+    public int $edible_species;
+    public int $brasilian_type_species;
+
+    public static function buildGeneralInfo(
+        int $threatened, 
+        int $occurrences, 
+        int $edible_species, 
+        int $brasilian_type_species): GeneralInfoResponse
+    {
+        $generalInfo = new GeneralInfoResponse();
+        $generalInfo->threatened = $threatened;
+        $generalInfo->occurrences = $occurrences;
+        $generalInfo->edible_species = $edible_species;
+        $generalInfo->brasilian_type_species = $brasilian_type_species;
+
+        return $generalInfo;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,7 +11,8 @@ class AppServiceProvider extends ServiceProvider
         \App\Services\Contracts\FungiContract::class => \App\Services\FungiService::class,
         \App\Services\Contracts\AuthContract::class => \App\Services\AuthService::class,
         \App\Services\Contracts\UserContract::class => \App\Services\UserService::class,
-        \App\Services\Contracts\OccurrenceContract::class => \App\Services\OccurrenceService::class
+        \App\Services\Contracts\OccurrenceContract::class => \App\Services\OccurrenceService::class,
+        \App\Services\Contracts\GeneralInfoContract::class => \App\Services\GeneralInfoService::class
     ];
 
     /**

--- a/app/Repositories/FungiRepository.php
+++ b/app/Repositories/FungiRepository.php
@@ -184,4 +184,24 @@ class FungiRepository extends BaseRepository
 
         return $this;
     }
+
+    public function getBrasilianTypeAndBrasilianTypeSynomyn()
+    {
+        return $this
+            ->where('brazilian_type', 'T')
+            ->orWhere('brazilian_type_synonym', 'TS')
+            ->get();
+    }
+
+    public function getEdibleSpecies()
+    {
+        return Fungi::where('bem', '>=', 1)
+            ->orWhere('bem', '<=', 10)
+            ->get();
+    }
+
+    public function getThreatenedSpecies()
+    {   
+        return Fungi::where('threatened', '>=', 3)->get();
+    }
 }

--- a/app/Services/Contracts/GeneralInfoContract.php
+++ b/app/Services/Contracts/GeneralInfoContract.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Services\Contracts;
+
+use App\Http\Responses\GeneralInfoResponse;
+
+
+interface GeneralInfoContract
+{
+    public function getGeneralInfo(): GeneralInfoResponse;
+}

--- a/app/Services/GeneralInfoService.php
+++ b/app/Services/GeneralInfoService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\FungiRepository;
+use App\Repositories\OccurrenceRepository;
+use App\Http\Responses\GeneralInfoResponse;
+use App\Services\Contracts\GeneralInfoContract;
+
+
+class GeneralInfoService implements GeneralInfoContract
+{
+    private FungiRepository $fungiRepo;
+    private OccurrenceRepository $occurencyRepo;
+
+    public function __construct(OccurrenceRepository $occurencyRepo, FungiRepository $fungiRepo)
+    {
+        $this->fungiRepo = $fungiRepo;
+        $this->occurencyRepo = $occurencyRepo;
+    }
+
+    public function getGeneralInfo(): GeneralInfoResponse
+    {
+        try {
+            $occurrences = $this->occurencyRepo->all()->count();
+
+            $brasilian_type_species = $this->fungiRepo->getBrasilianTypeAndBrasilianTypeSynomyn()->count();
+
+            $edible_species = $this->fungiRepo->getEdibleSpecies()->count();
+            
+            $threatened = $this->fungiRepo->getThreatenedSpecies()->count();
+
+            return GeneralInfoResponse::buildGeneralInfo($threatened, $occurrences, $edible_species, $brasilian_type_species);
+           
+        } catch (\Throwable $th) {
+            throw $th;
+        }
+    }
+
+}

--- a/docs/infos/sub_menu.md
+++ b/docs/infos/sub_menu.md
@@ -1,0 +1,14 @@
+#### Method: **GET**
+#### Path: **apiUrl/api/infos/sub_menu**
+Lista as informações necessárias para montar o sub_menu de informações gerais.
+
+##### Response (200):
+Content-Type: application/json
+```
+{
+	"threatened": 18,
+	"occurrences": 535,
+	"edible_species": 539,
+	"brasilian_type_species": 69
+}
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,3 +43,7 @@ Route::group(['middleware' => ['auth:api', 'check.user.type:Admin,Specialist']],
         Route::delete('/{uuid}/delete', 'OccurrenceController@delete');
     });
 });
+
+Route::group(['prefix' => 'infos'], function () {
+    Route::get('/sub_menu', 'GeneralInfoController@getGeneralInfo');
+});


### PR DESCRIPTION
### O que este pr faz?
Este pr é relacionado com a task [BEM-23](https://pvsbenevides197.atlassian.net/jira/software/projects/BEM/boards/7?assignee=712020%3Aa1b713a9-4fb1-47b5-87a6-421fbb513842&label=api&selectedIssue=BEM-23)
Ele adiciona:
- Um novo endpoint  `infos/sub_menu` cujo contém com as informações necessárias para o sub menu de informações gerais.
- Adiciona documentação deste endpoint

### Contrato de retorno:

```
{
  "threatened": int,
  "occurrences": int,
  "edible_species": int,
  "brasilian_type_species": int
}
```

### Como testar
Realize uma chamada  utilizando o curl abaixo para visualizar as informações:

```
curl --request GET \
  --url http://localhost/api/infos/sub_menu \
  --header 'User-Agent: insomnia/10.1.0'
```

## Retorno do endpoint
![image](https://github.com/user-attachments/assets/eb829979-f167-4ae1-b6af-c4b86c5c7695)
